### PR TITLE
feat(docker): add docker commands to control-panel script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,15 @@ Install Instructions:
 
 Once install is complete, log out and back in again. You should  now be able to run the control-panel from anywhere by typing `control-panel` in a terminal.  You can also autocomplete by typing `cont` + <kbd>Tab</kbd>
 
- ### Docker setup instrutions:
- #### ⚠️ `This has to be done every update.`
+ ### 🐳 Docker instructions:
 
- 1. Open a Terminal (Ctrl + Alt + T)
- 2. ensure the working directory IS this repo (i.e. wherever it was cloned to)
- 3. Run `docker build -t control-panel .`
+To run the control-panel in a docker environment do the following:
 
- ### Docker run instructions:
+1. Open a Terminal (Ubuntu: Ctrl + Alt + T)
+2. Run the following: `control-panel --docker`
 
- 1. Open a Terminal (Ctrl + Alt + T)
- 2. Run `docker run -it control-panel`
+OR
+
+1. Open a Terminal (Ctrl + Alt + T)
+2. Ensure the working directory is this directory (i.e. `~/bin/hackerspace-scripts-2`)
+3. Run the following: `./control-panel --docker`

--- a/control-panel
+++ b/control-panel
@@ -1,36 +1,51 @@
 #!/bin/bash
 
-installdir="/home/$USER/bin/hackerspace-scripts-2"
-FILE="/home/$USER/.profile"
-localdir="$(pwd)"
-string="export PATH=\$PATH:$localdir/"
-
-cd $installdir
-
-echo -e "\n### UPDATING ###\n"
-
-git pull
-
-if grep -q "$string" $FILE; then
-    echo "Already installed"
+if [ ! $# -eq 0 ]; then
+	case "$1" in
+		--docker | -d)
+		  echo -e "\n### BUILDING DOCKER ENV ###\n"
+			docker build -t control-panel .
+			echo -e "\n### REMOVING DANGLING IMAGES ###\n"
+			docker rmi --force $(docker images -f "dangling=true" -q)
+			echo -e "\n### RUNNING IMAGE ###\n"
+			docker run -it control-panel
+			;;
+	  *)
+	    echo -e "\n[ERR]: Flag not recognized\n";;
+	esac
 else
-    echo -e "\n### INSTALLING COMMAND ###\n"
-    echo -e "export PATH=\$PATH:$localdir/" >> $FILE
-    echo "Next time you can log out then back in to use 'control-panel' anywhere from the command line.\n"
+  installdir="/home/$USER/bin/hackerspace-scripts-2"
+  FILE="/home/$USER/.profile"
+  localdir="$(pwd)"
+  string="export PATH=\$PATH:$localdir/"
+
+  cd $installdir
+
+  echo -e "\n### UPDATING ###\n"
+
+  git pull
+
+  if grep -q "$string" $FILE; then
+      echo "Already installed"
+  else
+      echo -e "\n### INSTALLING COMMAND ###\n"
+      echo -e "export PATH=\$PATH:$localdir/" >> $FILE
+      echo "Next time you can log out then back in to use 'control-panel' anywhere from the command line.\n"
+  fi
+
+  if ! test -f "$installdir/env/bin/activate"; then
+      echo -e "\n### INSTALLING PYTHON ENVIRONMENT ###\n"
+      python3 -m venv $installdir/env
+  fi
+
+  source $installdir/env/bin/activate
+
+  echo -e "\n### UPDATING PYTHON ENVIRONMENT ###\n"
+  pip install -r requirements.txt
+
+  echo -e "\n### CHECKING INSTALLED PACAKGES ###\n"
+  python $installdir/bootstrap.py
+
+  echo -e "\n### RUNNING CONTROL PANEL ###\n"
+  python $installdir/controlpanel.py
 fi
-
-if ! test -f "$installdir/env/bin/activate"; then
-    echo -e "\n### INSTALLING PYTHON ENVIRONMENT ###\n"
-    python3 -m venv $installdir/env
-fi
-
-source $installdir/env/bin/activate
-
-echo -e "\n### UPDATING PYTHON ENVIRONMENT ###\n"
-pip install -r requirements.txt
-
-echo -e "\n### CHECKING INSTALLED PACAKGES ###\n"
-python $installdir/bootstrap.py
-
-echo -e "\n### RUNNING CONTROL PANEL ###\n"
-python $installdir/controlpanel.py

--- a/control-panel
+++ b/control-panel
@@ -7,6 +7,8 @@ if [ ! $# -eq 0 ]; then
 			docker build -t control-panel .
 			echo -e "\n### REMOVING DANGLING IMAGES ###\n"
 			docker rmi --force $(docker images -f "dangling=true" -q)
+			echo -e "\n### REMOVING EXITED CONTAINERS S##\n"
+			docker rm $(docker ps -a -f status=exited -f status=created -q)
 			echo -e "\n### RUNNING IMAGE ###\n"
 			docker run -it control-panel
 			;;


### PR DESCRIPTION
A small update to the addition of docker, make it accessible through the control-panel script

(i.e. it can be called with `control-panel --docker`)