### PR TITLE
fix(puppet)!: fix remove_server_cert_cmd

### DIFF
--- a/scripts/Workstation_Management/puppet_clear_certificates.py
+++ b/scripts/Workstation_Management/puppet_clear_certificates.py
@@ -6,7 +6,7 @@ username = 'hackerspace_admin'
 
 
 def puppet_command(computer_number, password):
-    remove_server_cert_cmd = "/opt/puppetlabs/bin/puppetserver ca clean --certname {}.hackerspace.tbl".format(computer_number)
+    remove_server_cert_cmd = "/opt/puppetlabs/bin/puppetserver ca clean --certname tbl-h10-{}.hackerspace.tbl".format(computer_number)
 
     # now that we know we have a connected computer, ssh into it and try to run command
     ssh_connection_puppet = SSH(puppet_host, username, password)

--- a/scripts/Workstation_Management/run_command_on_computers.py
+++ b/scripts/Workstation_Management/run_command_on_computers.py
@@ -39,19 +39,12 @@ def run_command(computer_number=None, password=None, command=None, sudo=True):
 
 
 def run_command_on_computers(print_stdout=True, sudo=False):
-    password = getpass("Enter the admin password: ")
     command = utils.input_plus("Enter the command to run")
-    numbers = utils.input_styled("Enter the computer numbers, seperated by spaces \n"
-                                 "(where # is from hostname tbl-h10-#-s e.g: 2 15 30)\n"
-                                 " or 'all' to run on all computers: ")
+    num_list, password = utils.get_computers_prompt()
 
-    num_list = numbers.split()
-
-    if num_list == "":
-        return
-
-    if num_list[0] == "all":
-        num_list = [f"{i}" for i in range(0, 32)]  # list of strings.  0 will cause problem if int instead of str
+    # options was quit
+    if num_list is None and password is None:
+        return False
 
     outputs = []
 


### PR DESCRIPTION
fixes the computer hostname issue

and makes puppet_command usable without only entering the computer number