### PR TITLE
fix(view_or_remove_media): sftp

### DIFF
--- a/scripts/TVs/view_or_remove_media.py
+++ b/scripts/TVs/view_or_remove_media.py
@@ -60,7 +60,7 @@ def view_or_remove_media(username=None, tv=None):
             return False
 
         # format art file fullpath
-        if dir_contents.index(art_file) < merge_point:
+        if dir_contents.index(art_file) < merge_point + 1:
             art_file_full_path = filepath + art_file
         else:
             art_file_full_path = "{}/tv{}/".format(TV_ROOT, tv) + art_file


### PR DESCRIPTION
#### DESCRIPTION:
The sftp that was being called in `view_or_remove_media.py` was not correctly setup with its merge point (between outside of the username directory and inside [this is for video vs image])

TECHNICAL CHANGES:
- Fixed if statement from `if dir_contents.index(art_file) > merge_point:` -> `if dir_contents.index(art_file) > merge_point + 1`


RELATED ISSUES:
- Closes #145 (tested on a lab pc)