### PR TITLE
fix: reboot_pi

### DIFF
--- a/scripts/_utils/pi.py
+++ b/scripts/_utils/pi.py
@@ -18,8 +18,12 @@ PI_LIST = PI_TV_LIST + [
 
 def reboot_pi(hostname):
     ssh_connection = ssh.SSH(hostname, username, password)
-    # https://stackoverflow.com/questions/26117712/executing-reboot-command-over-ssh-using-paramiko
-    ssh_connection.send_cmd("shutdown -r now", sudo=True)
-    ssh_connection.close()
 
-    print("Rebooting... give it a moment to start back up before using.")
+    if ssh_connection.is_connected():
+        # https://stackoverflow.com/questions/26117712/executing-reboot-command-over-ssh-using-paramiko
+        ssh_connection.send_cmd("shutdown -r now", sudo=True)
+        ssh_connection.close()
+
+        print("Rebooting... give it a moment to start back up before using.")
+    else:
+        print("An error (unable to establish connection) occurred while trying to reboot the pi. (Make sure the pi is on?)")


### PR DESCRIPTION
#### DESCRIPTION:
This PR will add a slight logic change to a widely used method to ensure an SSH connection has been established before continuing, else it will print out an accurate statement about what has happened (i.e. connection unable to be established with pi)

TECHNICAL CHANGES:
- Added connection check for reboot_pi

RELATED ISSUES:
- Closes #161 